### PR TITLE
🎨 Palette: Add ARIA labels to NavBar mobile and icon buttons

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2025-02-27 - Added ARIA labels to icon-only navigation elements in NavBar
+**Learning:** Icon-only navigation links (like those for "My Journey" and "Plans") and toggle buttons (like the hamburger menu) in the top-level NavBar component were lacking `aria-label`s. This creates significant accessibility gaps for screen reader users who rely on these labels to understand the purpose of these key interface elements.
+**Action:** Always verify that icon-only interactive elements, especially those crucial to global navigation, have clear and descriptive `aria-label` attributes. Additionally, use `aria-expanded` on toggle buttons to communicate their state to assistive technologies.

--- a/src/Components/NavBar/NavBar.jsx
+++ b/src/Components/NavBar/NavBar.jsx
@@ -69,6 +69,7 @@ export default function NavBar() {
               `relative flex items-center justify-center w-10 h-10 transition-colors duration-300 ${isActive ? 'text-orange-600' : 'text-orange-400'}`
             }
             title="My Journey"
+            aria-label="My Journey"
           >
             {({ isActive }) => (
               <>
@@ -112,6 +113,7 @@ export default function NavBar() {
               `relative flex items-center justify-center w-10 h-10 transition-colors duration-300 ${isActive ? 'text-orange-600' : 'text-orange-400'}`
             }
             title="Plans"
+            aria-label="Plans"
           >
             {({ isActive }) => (
               <>
@@ -135,10 +137,15 @@ export default function NavBar() {
             )}
           </NavLink>
 
-          <button className="md:hidden text-orange-600" onClick={() => {
-            trigger("nudge")
-            setMenuOpen(true)
-          }}>
+          <button
+            className="md:hidden text-orange-600"
+            onClick={() => {
+              trigger("nudge")
+              setMenuOpen(true)
+            }}
+            aria-label="Open main menu"
+            aria-expanded={menuOpen}
+          >
             <FiMenu size={26} />
           </button>
         </div>
@@ -175,6 +182,7 @@ export default function NavBar() {
                 trigger("success")
                 setMenuOpen(false)
               }}
+              aria-label="Close main menu"
             >
               <FiX />
             </button>


### PR DESCRIPTION
💡 What: Added `aria-label` attributes to the "My Journey" and "Plans" icon-only `NavLink` components. Added `aria-label` and `aria-expanded` to the mobile hamburger menu button, and an `aria-label` to the side drawer close button. Also added a journal entry in `.Jules/palette.md`.
🎯 Why: To improve keyboard and screen reader accessibility for core navigation features, as icon-only interactive elements without ARIA labels present significant accessibility gaps.
♿ Accessibility: Provides proper contextual descriptions for critical interactive navigation elements used by screen readers, and accurately tracks the expanded state of the mobile menu.

---
*PR created automatically by Jules for task [10118694978618528103](https://jules.google.com/task/10118694978618528103) started by @GodwinOkronipa*