### PR TITLE
🎨 Palette: Accessible notification close buttons

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,3 +1,7 @@
 ## 2025-02-27 - Added ARIA labels to icon-only navigation elements in NavBar
 **Learning:** Icon-only navigation links (like those for "My Journey" and "Plans") and toggle buttons (like the hamburger menu) in the top-level NavBar component were lacking `aria-label`s. This creates significant accessibility gaps for screen reader users who rely on these labels to understand the purpose of these key interface elements.
 **Action:** Always verify that icon-only interactive elements, especially those crucial to global navigation, have clear and descriptive `aria-label` attributes. Additionally, use `aria-expanded` on toggle buttons to communicate their state to assistive technologies.
+
+## 2024-05-28 - Accessible Notification Close Buttons
+**Learning:** Found that globally used toast notification and achievement close buttons (X and FiX icons) were not accessible by keyboard focus and missing aria-labels. Notifications appear suddenly, and visually impaired or keyboard-only users might not be able to easily locate or dismiss them without proper labels or visible focus states.
+**Action:** Add aria-label and keyboard focus styles (focus:outline-none focus-visible:ring-2) to all notification and pop-over close buttons to ensure they can be interacted with predictably by all users.

--- a/src/AuthContext.jsx
+++ b/src/AuthContext.jsx
@@ -332,7 +332,8 @@ export const AuthProvider = ({ children }) => {
                
                <button 
                  onClick={() => setNotification(null)}
-                 className="p-1 hover:bg-gray-100 rounded-full transition-colors text-gray-400"
+                 className="p-1 hover:bg-gray-100 rounded-full transition-colors text-gray-400 focus:outline-none focus-visible:ring-2 focus-visible:ring-green-500"
+                 aria-label="Close notification"
                >
                  <FiX size={20} />
                </button>

--- a/src/Contexts/ToastContext.jsx
+++ b/src/Contexts/ToastContext.jsx
@@ -91,7 +91,8 @@ export const ToastProvider = ({ children }) => {
               </div>
               <button
                 onClick={() => removeToast(toast.id)}
-                className="flex-shrink-0 opacity-70 hover:opacity-100 transition-opacity"
+                className="flex-shrink-0 opacity-70 hover:opacity-100 transition-opacity focus:outline-none focus-visible:ring-2 focus-visible:ring-current rounded"
+                aria-label="Close notification"
               >
                 <X size={16} />
               </button>


### PR DESCRIPTION
💡 **What:** Added `aria-label="Close notification"` and visible keyboard focus styles (`focus:outline-none focus-visible:ring-2 focus-visible:ring-current rounded`) to the close buttons on pop-up notifications (`ToastContext.jsx` and `AuthContext.jsx`).

🎯 **Why:** To improve accessibility. Previously, these icon-only close buttons lacked explicit descriptions for screen readers and visual focus indicators, making it hard for keyboard and assistive technology users to find and interact with them to dismiss notifications.

♿ **Accessibility:** Improvements to screen reader interpretation via ARIA attributes, and visual keyboard navigation enhancement via Focus Visible styling matching the local themes.

---
*PR created automatically by Jules for task [3136031644781460012](https://jules.google.com/task/3136031644781460012) started by @GodwinOkronipa*